### PR TITLE
Remove psutil

### DIFF
--- a/lib/harmonization.py
+++ b/lib/harmonization.py
@@ -14,7 +14,7 @@
 # ===============================================================================
 
 from plumbum import cli
-from distutils.spawn import find_executable
+from shutil import which
 import multiprocessing
 import io
 
@@ -428,7 +428,7 @@ class pipeline(cli.Application):
             'unring.a64']
 
         for cmd in external_commands:
-            exe= find_executable(cmd)
+            exe= which(cmd)
             if not exe:
                 raise EnvironmentError(f'{cmd} not found')
 

--- a/lib/harmonization.py
+++ b/lib/harmonization.py
@@ -15,14 +15,14 @@
 
 from plumbum import cli
 from distutils.spawn import find_executable
-import multiprocessing, psutil
+import multiprocessing
 import io
 
 from determineNshm import verifyNshmForAll, determineNshm
 from util import *
 from fileUtil import read_caselist, check_dir, check_csv
 
-N_CPU= psutil.cpu_count()
+N_CPU= multiprocessing.cpu_count()
 SCRIPTDIR= dirname(__file__)
 
 

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -14,8 +14,8 @@
 # ===============================================================================
 
 from plumbum import cli
-import psutil
-N_CPU= str(psutil.cpu_count())
+import multiprocessing
+N_CPU= str(multiprocessing.cpu_count())
 from conversion import read_bvals
 from util import dirname, basename, pjoin, SCRIPTDIR, remove, isfile
 from subprocess import check_call

--- a/lib/resampling.py
+++ b/lib/resampling.py
@@ -18,6 +18,7 @@ from scipy.ndimage import binary_opening, generate_binary_structure
 from scipy.io import loadmat, savemat
 from normalize import normalize_data, find_b0
 from util import *
+from os import getenv
 
 
 def resize_spm(lowResImg, inPrefix):
@@ -27,7 +28,7 @@ def resize_spm(lowResImg, inPrefix):
     savemat(dataFile, {'lowResImg': lowResImg})
 
     # call MATLAB_Runtime based spm bspline interpolation
-    p= Popen((' ').join([pjoin(SCRIPTDIR,'spm_bspline_exec', 'bspline'), inPrefix]), shell= True)
+    p= Popen((' ').join([pjoin(SCRIPTDIR,'spm_bspline_exec', 'run_bspline.sh'), getenv('MCRROOT'), inPrefix]), shell= True)
     p.wait()
     highResImg= np.nan_to_num(loadmat(inPrefix+'_resampled.mat')['highResImg'])
 


### PR DESCRIPTION
* Remove psutil
* Remove which
* Replace `bspline` with `run_bspline.sh` so `MCRROOT` can be set only for bspline interpolation