### PR TITLE
Include dedicated test for multi-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ But you can use the same bash environment that you have set up for multi-shell s
 A small test data is provided with each [release](https://github.com/pnlbwh/dMRIharmonization/releases).
 Instruction for running tests can be found [here](https://github.com/pnlbwh/dMRIharmonization?tab=readme-ov-file#1-pipeline).
 
-<sup>~</sup>This wiki explains why multi-shell software will not produce good results for single-shell test.
+<sup>~</sup> This wiki explains why multi-shell software will not produce good results for single-shell test.
 
 # Preprocessing
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Table of Contents
          * [1. Same target list](#1-same-target-list)
          * [2. Different target list](#2-different-target-list)
    * [Tests](#tests)
-      * [1. Single shell](#1-single-shell)
-      * [2. Multi shell](#2-multi-shell)
+      * [1. Multi shell](#1-multi-shell)
+      * [2. Single shell](#2-single-shell)
    * [Preprocessing](#preprocessing)
    * [Debugging](#debugging)
       * [1. With the pipeline](#1-with-the-pipeline)
@@ -342,19 +342,21 @@ The steps are described below:
 
 # Tests
 
-## 1. Single shell
-
-A small test data is provided with each [release](https://github.com/pnlbwh/dMRIharmonization/releases).
-Instruction for running tests can be found [here](https://github.com/pnlbwh/dMRIharmonization?tab=readme-ov-file#1-pipeline).
-
-## 2. Multi shell
+## 1. Multi shell
 
 A small test data is provided via [Dropbox](https://www.dropbox.com/scl/fi/lx4d6vslyzs64rehbki45/multi-harm-test.zip?rlkey=0ox9pmg3gu04xs6hzl6jvctgt&st=o2qlfxn0).
 Instruction for running tests can be found [here](lib/tests/README.md).
 
 Success of this test will confirm that your environment is properly set up to run multi-shell-dMRIharmonization.
 
+## 2. Single shell
 
+For this test, you should<sup>~</sup> clone the single-shell [software](https://github.com/pnlbwh/dMRIharmonization).
+But you can use the same bash environment that you have set up for multi-shell software.
+A small test data is provided with each [release](https://github.com/pnlbwh/dMRIharmonization/releases).
+Instruction for running tests can be found [here](https://github.com/pnlbwh/dMRIharmonization?tab=readme-ov-file#1-pipeline).
+
+<sup>~</sup>This wiki explains why multi-shell software will not produce good results for single-shell test.
 
 # Preprocessing
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ But you can use the same bash environment that you have set up for multi-shell s
 A small test data is provided with each [release](https://github.com/pnlbwh/dMRIharmonization/releases).
 Instruction for running tests can be found [here](https://github.com/pnlbwh/dMRIharmonization?tab=readme-ov-file#1-pipeline).
 
-<sup>~</sup> This wiki explains why multi-shell software will not produce good results for single-shell test.
+<sup>~</sup> This [wiki](https://github.com/pnlbwh/multi-shell-dMRIharmonization/wiki/Use-single%E2%80%90shell-software-for-single%E2%80%90shell-test) explains why multi-shell software will not produce good results for single-shell test.
 
 # Preprocessing
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Table of Contents
          * [1. Same target list](#1-same-target-list)
          * [2. Different target list](#2-different-target-list)
    * [Tests](#tests)
-      * [1. pipeline](#1-pipeline)
-      * [2. unittest](#2-unittest)
+      * [1. Single shell](#1-single-shell)
+      * [2. Multi shell](#2-multi-shell)
    * [Preprocessing](#preprocessing)
    * [Debugging](#debugging)
       * [1. With the pipeline](#1-with-the-pipeline)
@@ -342,17 +342,18 @@ The steps are described below:
 
 # Tests
 
-## 1. pipeline
+## 1. Single shell
 
 A small test data is provided with each [release](https://github.com/pnlbwh/dMRIharmonization/releases).
 Instruction for running tests can be found [here](https://github.com/pnlbwh/dMRIharmonization?tab=readme-ov-file#1-pipeline).
 
+## 2. Multi shell
+
+A small test data is provided via [Dropbox](https://www.dropbox.com/scl/fi/lx4d6vslyzs64rehbki45/multi-harm-test.zip?rlkey=0ox9pmg3gu04xs6hzl6jvctgt&st=o2qlfxn0).
+Instruction for running tests can be found [here](lib/tests/README.md).
+
 Success of this test will confirm that your environment is properly set up to run multi-shell-dMRIharmonization.
 
-
-## 2. unittest
-
-**TBD** 
 
 
 # Preprocessing

--- a/lib/tests/README.md
+++ b/lib/tests/README.md
@@ -1,10 +1,23 @@
-Execution of 
+### Running
 
-* `preHarmWarp_test`
-* `postHarmWarp_test`
-* `shellEquate`
+The whole multi-shell pipeline can be run as follows:
 
-will need PYTHONPATH to be defined like:
+> ./pipeline_test_multi_shell.sh
 
-    export PYTHONPATH=/path/to/multi-shell-dMRIharmonization/lib/
+
+### Results
+
+After running, compare the results with `multi-harm-test/template/meanFAstat*png` files:
+
+#### b=200 shell
+<img width="640" height="480" alt="Image" src="https://github.com/user-attachments/assets/8b83b85a-8e64-406d-b9f9-e31c5062a99a" />
+
+#### b=500 shell
+<img width="640" height="480" alt="Image" src="https://github.com/user-attachments/assets/5abe16d3-6f28-4444-b73a-357adc449ba1" />
+
+#### b=1500 shell
+<img width="640" height="480" alt="Image" src="https://github.com/user-attachments/assets/fd8aea31-ff05-4db1-9fc7-7a7a98b00599" />
+
+#### b=3000 shell
+<img width="640" height="480" alt="Image" src="https://github.com/user-attachments/assets/91edf0b2-f670-4cb9-803c-5467bccee370" />
 

--- a/lib/tests/pipeline_test.sh
+++ b/lib/tests/pipeline_test.sh
@@ -58,7 +58,7 @@ write_list prisma.txt
 ### Run pipeline and obtain statistics when same number of matched reference and target images are used in
 ### tempalate creation and harmonization
 # run test
-../../multi-shell-harmonization.py \
+../../harmonization.py \
 --template ./template-multi/ \
 --ref_list connectom.txt \
 --tar_list prisma.txt \

--- a/lib/tests/pipeline_test_multi_shell.sh
+++ b/lib/tests/pipeline_test_multi_shell.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# download test data
+test_data=multi-harm-test # change this value if test data name is changed
+if [ ! -f ${test_data}.zip ]
+then
+    wget wget "https://www.dropbox.com/scl/fi/lx4d6vslyzs64rehbki45/multi-harm-test.zip?rlkey=0ox9pmg3gu04xs6hzl6jvctgt&st=o2qlfxn0" -O ${test_data}.zip
+fi
+
+unzip ${test_data}.zip
+
+cd ${test_data}
+CURRDIR=`pwd`
+
+# append path to image list
+sed -i "s+TESTDIR+$CURRDIR+g" *csv
+
+### Run pipeline and obtain statistics when same number of matched reference and target images are used in
+### tempalate creation and harmonization
+# run test
+./run.sh
+
+

--- a/lib/tests/pipeline_test_multi_shell.sh
+++ b/lib/tests/pipeline_test_multi_shell.sh
@@ -4,7 +4,7 @@
 test_data=multi-harm-test # change this value if test data name is changed
 if [ ! -f ${test_data}.zip ]
 then
-    wget wget "https://www.dropbox.com/scl/fi/lx4d6vslyzs64rehbki45/multi-harm-test.zip?rlkey=0ox9pmg3gu04xs6hzl6jvctgt&st=o2qlfxn0" -O ${test_data}.zip
+    wget "https://www.dropbox.com/scl/fi/lx4d6vslyzs64rehbki45/multi-harm-test.zip?rlkey=0ox9pmg3gu04xs6hzl6jvctgt&st=o2qlfxn0" -O ${test_data}.zip
 fi
 
 unzip ${test_data}.zip


### PR DESCRIPTION
* Added independent tests for multi-shell software (data is distributed via MGB Dropbox)
* Enhanced `lib/tests/README.md` with test results
* Restored single-shell test to its pristine form
* Added a wiki explaining why single-shell repo should be used for single-shell test
* Reordered main README.md