### PR TITLE
Use the diffusion shell closest to b1000 for template construction

### DIFF
--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -185,6 +185,9 @@ class multi_shell_pipeline(cli.Application):
         # b=0 is skipped; non-zero shells are ordered with target_bval first, then by proximity to target_bval, then descending
         ref_bvals= read_bvals(ref_bvals_file)[::-1]
 
+        if int(self.bshell_for_template_construction) not in ref_bvals:
+            raise ValueError(f"bshell_for_template_construction value {self.bshell_for_template_construction} is not in the reference b-shells: {ref_bvals}")
+        
         target_bval = int(self.bshell_for_template_construction)
 
         ref_bvals_ordered = sorted(

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -74,6 +74,11 @@ class multi_shell_pipeline(cli.Application):
         help= 'number of zero padding for denoising skull region during signal reconstruction',
         default= '10')
 
+    bshell_for_template_construction = cli.SwitchAttr(
+        '--bshell_for_template_construction',
+        help= 'b-shell bvalue to use for template construction (default: 1000)',
+        default= '1000')
+    
     force = cli.Flag(
         ['--force'],
         help='turn on this flag to overwrite existing data',
@@ -177,13 +182,10 @@ class multi_shell_pipeline(cli.Application):
         if self.verbose:
             pipeline_vars.append('--verbose')
         
-
-        # the b-shell bvalues are sorted in descending order because we want to perform registration with highest bval
-        # because L0 maps from high b-shells would look too similar to FA, the b-shell bvalues are reordered to perform
-        # the template construction with B=1000
+        # b=0 is skipped; non-zero shells are ordered with target_bval first, then by proximity to target_bval, then descending
         ref_bvals= read_bvals(ref_bvals_file)[::-1]
 
-        target_bval = 1000
+        target_bval = int(self.bshell_for_template_construction)
 
         ref_bvals_ordered = sorted(
             ref_bvals,

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -74,8 +74,8 @@ class multi_shell_pipeline(cli.Application):
         help= 'number of zero padding for denoising skull region during signal reconstruction',
         default= '10')
 
-    bshell_for_template_construction = cli.SwitchAttr(
-        '--bshell_for_template_construction',
+    bshell_template = cli.SwitchAttr(
+        '--bshell_template',
         help= 'b-shell bvalue to use for template construction',
         default= '1000')
     
@@ -185,10 +185,10 @@ class multi_shell_pipeline(cli.Application):
         # b=0 is skipped; non-zero shells are ordered with target_bval first, then by proximity to target_bval, then descending
         ref_bvals= read_bvals(ref_bvals_file)[::-1]
 
-        if int(self.bshell_for_template_construction) not in ref_bvals:
-            raise ValueError(f"bshell_for_template_construction value {self.bshell_for_template_construction} is not in the reference b-shells: {ref_bvals}")
+        if int(self.bshell_template) not in ref_bvals:
+            raise ValueError(f"bshell_template value {self.bshell_template} is not in the reference b-shells: {ref_bvals}")
         
-        target_bval = int(self.bshell_for_template_construction)
+        target_bval = int(self.bshell_template)
 
         ref_bvals_ordered = sorted(
             ref_bvals,

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -179,8 +179,21 @@ class multi_shell_pipeline(cli.Application):
         
 
         # the b-shell bvalues are sorted in descending order because we want to perform registration with highest bval
+        # because L0 maps from high b-shells would look too similar to FA, the b-shell bvalues are reordered to perform
+        # the template construction with B=1000
         ref_bvals= read_bvals(ref_bvals_file)[::-1]
-        for bval in ref_bvals[ :-1]: # pass the last bval which is 0.
+
+        target_bval = 1000
+        threshold = 50
+
+        ref_bvals_ordered = sorted(
+            ref_bvals,
+            key=lambda b: (abs(b - target_bval) > threshold, b == 0)
+        )
+
+        for bval in ref_bvals_reodered:
+            if bval == 0:
+                continue
 
             if self.create and not self.process:
                 print('## template creation ##')

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -76,7 +76,7 @@ class multi_shell_pipeline(cli.Application):
 
     bshell_for_template_construction = cli.SwitchAttr(
         '--bshell_for_template_construction',
-        help= 'b-shell bvalue to use for template construction (default: 1000)',
+        help= 'b-shell bvalue to use for template construction',
         default= '1000')
     
     force = cli.Flag(

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -191,7 +191,7 @@ class multi_shell_pipeline(cli.Application):
             key=lambda b: (b == 0, abs(b - target_bval), -b)
         )
 
-        for bval in ref_bvals_reodered:
+        for bval in ref_bvals_ordered:
             if bval == 0:
                 continue
 

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -188,7 +188,7 @@ class multi_shell_pipeline(cli.Application):
 
         ref_bvals_ordered = sorted(
             ref_bvals,
-            key=lambda b: (abs(b - target_bval) > threshold, b == 0)
+            key=lambda b: (b == 0, abs(b - target_bval), -b)
         )
 
         for bval in ref_bvals_reodered:

--- a/lib/multi-shell-harmonization.py
+++ b/lib/multi-shell-harmonization.py
@@ -184,7 +184,6 @@ class multi_shell_pipeline(cli.Application):
         ref_bvals= read_bvals(ref_bvals_file)[::-1]
 
         target_bval = 1000
-        threshold = 50
 
         ref_bvals_ordered = sorted(
             ref_bvals,


### PR DESCRIPTION
The template construction step uses the FA and L0 maps from the selected diffusion shell. While using the highest shell generally works well for datasets with conventional diffusion acquisitions, it can be suboptimal when very high b-value shells (e.g., b3000) are available because the resulting L0 maps have substantially different image contrast.

At high b-values, CSF signal is strongly attenuated, whereas WM retains relatively more signal. Consequently, L0 maps estimated from the b3000 shell exhibit increased WM-to-CSF contrast and appear more FA-like than L0 maps from lower b-value shells. This reduces the complementary anatomical contrast between the FA and L0 maps, particularly around tissue interfaces and the brain boundary, which can affect image registration during template construction.

This PR modifies the template construction step to preferentially use the diffusion shell closest to b1000 instead of the highest b-value shell. If multiple shells are equally close to b1000, the pipeline selects the higher b-value shell.

In our testing, this change resolved the two ref–target cases that previously produced suboptimal registrations when the pipeline selected the b3000 shell for template construction.